### PR TITLE
Add chinese language support to astro project

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -80,6 +80,16 @@ export default defineConfig({
     rehypePlugins: [responsiveTablesRehypePlugin, lazyImagesRehypePlugin],
   },
 
+  // Enable Astro built-in i18n
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'zh-CN', 'zh-TW'],
+    routing: {
+      // Do not prefix default locale (en) with /en
+      prefixDefaultLocale: false,
+    },
+  },
+
   vite: {
     resolve: {
       alias: {

--- a/src/components/common/LanguagePicker.astro
+++ b/src/components/common/LanguagePicker.astro
@@ -39,7 +39,7 @@ const langUrls = (Object.entries(languages) as Array<[keyof typeof languages, st
   </button>
 
   <div
-    class="hidden absolute right-0 z-10 mt-2 w-40 origin-top-right rounded-md bg-white dark:bg-slate-800 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+    class="hidden absolute right-0 z-10 w-40 origin-bottom-right md:origin-top-right bottom-full mb-2 md:bottom-auto md:top-full md:mt-2 md:mb-0 rounded-md bg-white dark:bg-slate-800 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
     role="menu"
     aria-orientation="vertical"
     aria-labelledby="language-picker-button"

--- a/src/components/common/LanguagePicker.astro
+++ b/src/components/common/LanguagePicker.astro
@@ -1,0 +1,96 @@
+---
+import { languages, stripLocaleFromPath } from '~/i18n/utils';
+
+const currentPath = Astro.url.pathname;
+const currentLang = (Astro.currentLocale as keyof typeof languages) || 'en';
+
+const pathWithoutLang = stripLocaleFromPath(currentPath);
+
+const langUrls = (Object.entries(languages) as Array<[keyof typeof languages, string]>).map(([code, name]) => ({
+  code,
+  name,
+  url: code === 'en' ? pathWithoutLang : `/${code}${pathWithoutLang === '/' ? '' : pathWithoutLang}`,
+  active: currentLang === code,
+}));
+---
+
+<div class="relative inline-block text-left" id="language-picker">
+  <button
+    type="button"
+    class="inline-flex items-center gap-x-1 text-sm font-semibold leading-6 text-gray-900 dark:text-gray-200 hover:text-primary-600 dark:hover:text-primary-400"
+    aria-expanded="false"
+    id="language-picker-button"
+  >
+    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"
+      ></path>
+    </svg>
+    <span>{languages[currentLang]}</span>
+    <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path
+        fill-rule="evenodd"
+        d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+        clip-rule="evenodd"></path>
+    </svg>
+  </button>
+
+  <div
+    class="hidden absolute right-0 z-10 mt-2 w-40 origin-top-right rounded-md bg-white dark:bg-slate-800 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+    role="menu"
+    aria-orientation="vertical"
+    aria-labelledby="language-picker-button"
+    tabindex="-1"
+    id="language-picker-menu"
+  >
+    <div class="py-1" role="none">
+      {
+        langUrls.map(({ name, url, active }) => (
+          <a
+            href={url}
+            class:list={[
+              'block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-slate-700',
+              {
+                'text-gray-900 dark:text-gray-200': !active,
+                'text-primary-600 dark:text-primary-400 font-semibold': active,
+              },
+            ]}
+            role="menuitem"
+            tabindex="-1"
+          >
+            {name}
+          </a>
+        ))
+      }
+    </div>
+  </div>
+</div>
+
+<script>
+  function setupLanguagePicker() {
+    const button = document.getElementById('language-picker-button');
+    const menu = document.getElementById('language-picker-menu');
+
+    if (!button || !menu) return;
+
+    button.addEventListener('click', () => {
+      const isHidden = menu.classList.contains('hidden');
+      menu.classList.toggle('hidden', !isHidden);
+      button.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
+    });
+
+    document.addEventListener('click', (event) => {
+      const picker = document.getElementById('language-picker');
+      if (picker && !picker.contains(event.target as Node)) {
+        menu.classList.add('hidden');
+        button.setAttribute('aria-expanded', 'false');
+      }
+    });
+  }
+
+  setupLanguagePicker();
+  document.addEventListener('astro:after-swap', setupLanguagePicker);
+</script>

--- a/src/components/widgets/Footer.astro
+++ b/src/components/widgets/Footer.astro
@@ -2,6 +2,7 @@
 import { Icon } from 'astro-icon/components';
 import { SITE } from 'astrowind:config';
 import { getHomePermalink } from '~/utils/permalinks';
+import { localizePath, defaultLocale } from '~/i18n/utils';
 
 interface Link {
   text?: string;
@@ -24,6 +25,7 @@ export interface Props {
 }
 
 const { socialLinks = [], secondaryLinks = [], links = [], footNote = '', theme = 'light' } = Astro.props;
+const currentLocale = Astro.currentLocale || defaultLocale;
 ---
 
 <footer class:list={[{ dark: theme === 'dark' }, 'relative border-t border-gray-200 dark:border-slate-800 not-prose']}>
@@ -34,7 +36,9 @@ const { socialLinks = [], secondaryLinks = [], links = [], footNote = '', theme 
     <div class="grid grid-cols-12 gap-4 gap-y-8 sm:gap-8 py-8 md:py-12">
       <div class="col-span-12 lg:col-span-4">
         <div class="mb-2">
-          <a class="inline-block font-bold text-xl" href={getHomePermalink()}>{SITE?.name}</a>
+          <a class="inline-block font-bold text-xl" href={localizePath(getHomePermalink(), currentLocale)}
+            >{SITE?.name}</a
+          >
         </div>
         <div class="text-sm text-muted flex gap-1">
           {
@@ -43,7 +47,7 @@ const { socialLinks = [], secondaryLinks = [], links = [], footNote = '', theme 
                 {index !== 0 ? ' · ' : ''}
                 <a
                   class="text-muted hover:text-gray-700 dark:text-gray-400 hover:underline transition duration-150 ease-in-out"
-                  href={href}
+                  href={localizePath(href || '#', currentLocale)}
                   set:html={text}
                 />
               </>
@@ -61,7 +65,7 @@ const { socialLinks = [], secondaryLinks = [], links = [], footNote = '', theme 
                   <li class="mb-2">
                     <a
                       class="text-muted hover:text-gray-700 hover:underline dark:text-gray-400 transition duration-150 ease-in-out"
-                      href={href}
+                      href={localizePath(href || '#', currentLocale)}
                       aria-label={ariaLabel}
                     >
                       <Fragment set:html={text} />

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -2,11 +2,13 @@
 import { Icon } from 'astro-icon/components';
 import Logo from '~/components/Logo.astro';
 import ToggleTheme from '~/components/common/ToggleTheme.astro';
+import LanguagePicker from '~/components/common/LanguagePicker.astro';
 import ToggleMenu from '~/components/common/ToggleMenu.astro';
 import Button from '~/components/ui/Button.astro';
 
 import { getHomePermalink } from '~/utils/permalinks';
 import { trimSlash, getAsset } from '~/utils/permalinks';
+import { localizePath, defaultLocale } from '~/i18n/utils';
 import type { CallToAction } from '~/types';
 
 interface Link {
@@ -45,6 +47,8 @@ const {
 } = Astro.props;
 
 const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
+const currentLocale = Astro.currentLocale || defaultLocale;
+const homeHref = localizePath(getHomePermalink(), currentLocale);
 ---
 
 <header
@@ -71,7 +75,7 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
     ]}
   >
     <div class:list={[{ 'mr-auto rtl:mr-0 rtl:ml-auto': position === 'right' }, 'flex justify-between']}>
-      <a class="flex items-center" href={getHomePermalink()}>
+      <a class="flex items-center" href={homeHref}>
         <Logo />
       </a>
       <div class="flex items-center md:hidden">
@@ -103,9 +107,9 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
                         <a
                           class:list={[
                             'first:rounded-t last:rounded-b md:hover:bg-gray-100 hover:text-link dark:hover:text-white dark:hover:bg-gray-700 py-2 px-5 block whitespace-no-wrap',
-                            { 'aw-link-active': href2 === currentPath },
+                            { 'aw-link-active': localizePath(href2 || '#', currentLocale) === currentPath },
                           ]}
-                          href={href2}
+                          href={localizePath(href2 || '#', currentLocale)}
                         >
                           {text2}
                         </a>
@@ -117,9 +121,9 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
                 <a
                   class:list={[
                     'hover:text-link dark:hover:text-white px-4 py-3 flex items-center whitespace-nowrap',
-                    { 'aw-link-active': href === currentPath },
+                    { 'aw-link-active': localizePath(href || '#', currentLocale) === currentPath },
                   ]}
-                  href={href}
+                  href={localizePath(href || '#', currentLocale)}
                 >
                   {text}
                 </a>
@@ -136,8 +140,9 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
       ]}
     >
       <div class="items-center flex justify-between w-full md:w-auto">
-        <div class="flex">
+        <div class="flex items-center gap-2">
           {showToggleTheme && <ToggleTheme iconClass="w-6 h-6 md:w-5 md:h-5 md:inline-block" />}
+          <LanguagePicker />
           {
             showRssFeed && (
               <a

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,0 +1,43 @@
+import { I18N } from 'astrowind:config';
+
+export const languages = {
+  en: 'English',
+  'zh-CN': '简体中文',
+  'zh-TW': '繁體中文',
+} as const;
+
+export type LocaleCode = keyof typeof languages;
+
+export const defaultLocale: LocaleCode = (I18N.language as LocaleCode) || 'en';
+
+const supportedLocales: ReadonlyArray<LocaleCode> = ['en', 'zh-CN', 'zh-TW'];
+const localePrefixRegex = new RegExp(`^/(?:${supportedLocales.join('|')})(?=/|$)`);
+
+export function stripLocaleFromPath(pathname: string): string {
+  if (!pathname) return '/';
+  const urlPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  const stripped = urlPath.replace(localePrefixRegex, '') || '/';
+  return stripped.startsWith('/') ? stripped : `/${stripped}`;
+}
+
+export function isExternalOrSpecialLink(href: string): boolean {
+  return (
+    href.startsWith('http://') ||
+    href.startsWith('https://') ||
+    href.startsWith('mailto:') ||
+    href.startsWith('tel:') ||
+    href.startsWith('#') ||
+    href.startsWith('javascript:')
+  );
+}
+
+export function localizePath(href: string, locale: string): string {
+  if (!href) return '/';
+  if (isExternalOrSpecialLink(href)) return href;
+
+  const clean = stripLocaleFromPath(href);
+  if (locale === defaultLocale) {
+    return clean;
+  }
+  return `/${locale}${clean === '/' ? '' : clean}`;
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,11 +22,12 @@ export interface Props {
 }
 
 const { metadata = {} } = Astro.props;
-const { language, textDirection } = I18N;
+const { textDirection } = I18N;
+const currentLocale = Astro.currentLocale || I18N.language;
 ---
 
 <!doctype html>
-<html lang={language} dir={textDirection} class="2xl:text-[20px]">
+<html lang={currentLocale} dir={textDirection} class="2xl:text-[20px]">
   <head>
     <CommonMeta />
     <Favicons />

--- a/src/pages/zh-CN/about.astro
+++ b/src/pages/zh-CN/about.astro
@@ -10,13 +10,13 @@ const metadata = {
 <Layout metadata={metadata}>
   <Content
     title="DeepAcquire"
-    subtitle="用 AI 釋放你的心智——更快！"
+    subtitle="用 AI 加速你的心智——更快！"
     image={`<img src="${aboutImg.src}" alt="关于我们" class="mx-auto w-full rounded-lg bg-gray-500 shadow-lg" loading="lazy" />`}
   >
     <Fragment slot="content">
       <p>我们成立于 2025 年。</p>
       <p>我们最初的愿景是：既然已经拥有超级智能的 AI，人类如何能快速获得并融合 AI 的智慧？</p>
-      <p>像运用自己的心智一样自然地调用 AI 的智慧——或让我们的心智快速获得类 AI 能力。</p>
+      <p>像运用自己的心智一样自然地调用 AI 的智慧——或者我们的大脑能够快速拥有 AI 般的能力。</p>
       <p>
         在这个愿景的引导下，我们打造了第一款产品，<span class="font-semibold text-accent">Acquire Language</span>。它以
         AI 加速多语言学习。

--- a/src/pages/zh-CN/about.astro
+++ b/src/pages/zh-CN/about.astro
@@ -1,0 +1,27 @@
+---
+import Content from '~/components/widgets/Content.astro';
+import Layout from '~/layouts/PageLayout.astro';
+import aboutImg from '~/assets/images/acquire/about-us.jpg';
+const metadata = {
+  title: '关于我们',
+};
+---
+
+<Layout metadata={metadata}>
+  <Content
+    title="DeepAcquire"
+    subtitle="用 AI 釋放你的心智——更快！"
+    image={`<img src="${aboutImg.src}" alt="关于我们" class="mx-auto w-full rounded-lg bg-gray-500 shadow-lg" loading="lazy" />`}
+  >
+    <Fragment slot="content">
+      <p>我们成立于 2025 年。</p>
+      <p>我们最初的愿景是：既然已经拥有超级智能的 AI，人类如何能快速获得并融合 AI 的智慧？</p>
+      <p>像运用自己的心智一样自然地调用 AI 的智慧——或让我们的心智快速获得类 AI 能力。</p>
+      <p>
+        在这个愿景的引导下，我们打造了第一款产品，<span class="font-semibold text-accent">Acquire Language</span>。它以
+        AI 加速多语言学习。
+      </p>
+      <p>这只是一个开始……</p>
+    </Fragment>
+  </Content>
+</Layout>

--- a/src/pages/zh-CN/index.astro
+++ b/src/pages/zh-CN/index.astro
@@ -1,0 +1,129 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import extIcon from '~/assets/images/acquire/icon-128.png';
+import heroImage from '~/assets/images/acquire/hero.png';
+import screenshotEn from '~/assets/images/acquire/screenshot-en.png';
+import setupReady from '~/assets/images/acquire/setup-ready.jpg';
+
+import Hero from '~/components/widgets/Hero.astro';
+import Features from '~/components/widgets/Features.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import Content from '~/components/widgets/Content.astro';
+
+const metadata = {
+  title: 'Acquire Language — 用你喜爱的视频学习语言',
+  ignoreTitleTemplate: true,
+};
+---
+
+<Layout metadata={metadata}>
+  <Hero
+    actions={[
+      {
+        variant: 'primary',
+        text: `<img src="${extIcon.src}" alt="Acquire Language 图标" class="w-5 h-5 inline-block mr-2 rounded" width="20" height="20" />安装扩展`,
+        href: '#install',
+      },
+      { text: '了解更多', href: '#features' },
+    ]}
+    image={`<img src="${heroImage.src}" alt="Acquire Language 头图" class="mx-auto rounded-md w-full" width="1280" height="800" loading="eager" />`}
+  >
+    <Fragment slot="title">
+      通过观看 <span class="hidden xl:inline">YouTube</span>
+      <span class="text-accent dark:text-white">Acquire Language</span> 学习语言
+    </Fragment>
+
+    <Fragment slot="subtitle">
+      <span class="hidden sm:inline">AI 加持的字幕、悬停释义与生词本。使用你自己的 AI 服务商进行翻译，无额外加价。</span
+      >
+      <span class="block mb-1 sm:hidden font-bold text-blue-600">Acquire Language：边看边学。</span>
+      增强 YouTube 字幕，保存语境中的词汇，提出追问。
+    </Fragment>
+  </Hero>
+
+  <Features
+    id="features"
+    tagline="功能"
+    title="Acquire Language 能为你带来什么"
+    subtitle="通过增强字幕、即时释义与个性化生词本，自然习得语言。"
+    items={[
+      {
+        title: '增强 AI 字幕',
+        description: '改进 YouTube 字幕排版，使用你选择的 AI 服务获得准确翻译。',
+        icon: 'tabler:message-language',
+      },
+      {
+        title: '悬停释义',
+        description: '获取即时释义。点击即可将单词、例句与笔记保存到生词本。',
+        icon: 'tabler:book-2',
+      },
+      { title: '生词本', description: '在观看视频的过程中积累词汇，连同语境一并保存。', icon: 'tabler:notebook' },
+      {
+        title: '灵活的 AI 服务商',
+        description: '自带你的 AI。连接多个服务商，无加价、无锁定。',
+        icon: 'tabler:arrows-right-left',
+      },
+      { title: '开放共建', description: '欢迎新想法与贡献，共同打造出色体验。', icon: 'tabler:bulb' },
+    ]}
+  />
+
+  <Content
+    id="install"
+    title="安装 Acquire Language"
+    subtitle="现已上架 Chrome 网上应用店。点击下方“添加至 Chrome”进行安装。即将支持 Microsoft Edge、Safari、Firefox。"
+    items={[
+      {
+        title: '语境感知解释——更易理解',
+        description: '不认识字幕里的词？悬停点击即可获得结合当前语境、贴合水平的 AI 解释。',
+      },
+      {
+        title: '有问题？继续追问',
+        description: '分不清相似词？继续在相同语境下追问，得到清晰解释。',
+      },
+      {
+        title: 'AI 翻译字幕——双语显示',
+        description: '想轻松看视频？Acquire Language 将字幕翻译为你的母语并双语显示。',
+      },
+      {
+        title: '同步生词本——随时复习',
+        description: '保存单词（含语境）、片段，甚至音频。同步到你常用的笔记应用，随时复习巩固。',
+      },
+    ]}
+    image={`<img src="${screenshotEn.src}" alt="安装 Acquire Language" class="mx-auto w-full rounded-lg bg-gray-500 shadow-lg" width="440" height="280" loading="lazy" />`}
+    callToAction={{
+      variant: 'primary',
+      text: '添加至 Chrome',
+      href: 'https://chrome.google.com/webstore/detail/pnobdlbfobamledoecdignpneeoohhio',
+      target: '_blank',
+      icon: 'tabler:brand-chrome',
+    }}
+  />
+
+  <Steps
+    title="设置 Acquire Language"
+    items={[
+      {
+        title: '步骤 1：<span class="font-medium">选择语言与水平</span>',
+        description: '设置你想学习的语言与当前水平，以更好地匹配学习需求',
+        icon: 'tabler:language',
+      },
+      {
+        title: '步骤 2：<span class="font-medium">配置 AI 服务</span>',
+        description: '打开 设置 -> AI 服务 配置你的 AI 服务',
+        icon: 'tabler:settings',
+      },
+      {
+        title: '步骤 3：<span class="font-medium">设置生词本同步</span>',
+        description: '配置欧路词典等集成，将生词同步到你的词汇本',
+        icon: 'tabler:arrows-right-left',
+      },
+      {
+        title: '步骤 4：<span class="font-medium">启用字幕</span>',
+        description: '打开任意 YouTube 视频并启用字幕',
+        icon: 'tabler:video',
+      },
+      { title: '准备就绪！', icon: 'tabler:check' },
+    ]}
+    image={`<img src="${setupReady.src}" alt="设置完成" class="mx-auto w-full rounded-lg shadow-lg" loading="lazy" />`}
+  />
+</Layout>

--- a/src/pages/zh-CN/index.astro
+++ b/src/pages/zh-CN/index.astro
@@ -30,7 +30,7 @@ const metadata = {
   >
     <Fragment slot="title">
       通过观看 <span class="hidden xl:inline">YouTube</span>
-      <span class="text-accent dark:text-white">Acquire Language</span> 学习语言
+      <span class="text-accent">Acquire Language</span> 学习语言
     </Fragment>
 
     <Fragment slot="subtitle">

--- a/src/pages/zh-TW/about.astro
+++ b/src/pages/zh-TW/about.astro
@@ -1,0 +1,27 @@
+---
+import Content from '~/components/widgets/Content.astro';
+import Layout from '~/layouts/PageLayout.astro';
+import aboutImg from '~/assets/images/acquire/about-us.jpg';
+const metadata = {
+  title: '關於我們',
+};
+---
+
+<Layout metadata={metadata}>
+  <Content
+    title="DeepAcquire"
+    subtitle="用 AI 釋放你的心智——更快！"
+    image={`<img src="${aboutImg.src}" alt="關於我們" class="mx-auto w-full rounded-lg bg-gray-500 shadow-lg" loading="lazy" />`}
+  >
+    <Fragment slot="content">
+      <p>我們成立於 2025 年。</p>
+      <p>我們最初的願景是：既然已經擁有超級智慧的 AI，人類如何能快速獲得並融合 AI 的智慧？</p>
+      <p>像運用自己的心智一樣自然地調用 AI 的智慧——或讓我們的心智快速獲得類 AI 能力。</p>
+      <p>
+        在這個願景的引導下，我們打造了第一款產品，<span class="font-semibold text-accent">Acquire Language</span>。它以
+        AI 加速多語言學習。
+      </p>
+      <p>這只是一個開始……</p>
+    </Fragment>
+  </Content>
+</Layout>

--- a/src/pages/zh-TW/index.astro
+++ b/src/pages/zh-TW/index.astro
@@ -1,0 +1,123 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import extIcon from '~/assets/images/acquire/icon-128.png';
+import heroImage from '~/assets/images/acquire/hero.png';
+import screenshotEn from '~/assets/images/acquire/screenshot-en.png';
+import setupReady from '~/assets/images/acquire/setup-ready.jpg';
+
+import Hero from '~/components/widgets/Hero.astro';
+import Features from '~/components/widgets/Features.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import Content from '~/components/widgets/Content.astro';
+
+const metadata = {
+  title: 'Acquire Language — 用你喜歡的影片學語言',
+  ignoreTitleTemplate: true,
+};
+---
+
+<Layout metadata={metadata}>
+  <Hero
+    actions={[
+      {
+        variant: 'primary',
+        text: `<img src="${extIcon.src}" alt="Acquire Language 圖示" class="w-5 h-5 inline-block mr-2 rounded" width="20" height="20" />安裝擴充功能`,
+        href: '#install',
+      },
+      { text: '了解更多', href: '#features' },
+    ]}
+    image={`<img src="${heroImage.src}" alt="Acquire Language 首圖" class="mx-auto rounded-md w-full" width="1280" height="800" loading="eager" />`}
+  >
+    <Fragment slot="title">
+      透過觀看 <span class="hidden xl:inline">YouTube</span>
+      <span class="text-accent dark:text-white">Acquire Language</span> 學語言
+    </Fragment>
+
+    <Fragment slot="subtitle">
+      <span class="hidden sm:inline"
+        >AI 加持字幕、滑過即顯示釋義、與單字本。可使用你自己的 AI 服務供應商，無額外加價。</span
+      >
+      <span class="block mb-1 sm:hidden font-bold text-blue-600">Acquire Language：邊看邊學。</span>
+      強化 YouTube 字幕、保存語境中的單字、並可追問。
+    </Fragment>
+  </Hero>
+
+  <Features
+    id="features"
+    tagline="功能"
+    title="Acquire Language 為你帶來什麼"
+    subtitle="以增強字幕、即時釋義、與個人化單字本，自然習得語言。"
+    items={[
+      {
+        title: '增強 AI 字幕',
+        description: '改良 YouTube 字幕排版，使用你選擇的 AI 服務取得精準翻譯。',
+        icon: 'tabler:message-language',
+      },
+      { title: '滑過釋義', description: '取得即時釋義。點擊即可將單字、例句與筆記存到單字本。', icon: 'tabler:book-2' },
+      { title: '單字本', description: '在觀看影片時累積單字，同步保存語境。', icon: 'tabler:notebook' },
+      {
+        title: '彈性的 AI 供應商',
+        description: '自帶你的 AI。可連接多個供應商，無加價無綁定。',
+        icon: 'tabler:arrows-right-left',
+      },
+      { title: '開放共創', description: '歡迎新想法與貢獻，共同打造出色體驗。', icon: 'tabler:bulb' },
+    ]}
+  />
+
+  <Content
+    id="install"
+    title="安裝 Acquire Language"
+    subtitle="現已上架 Chrome 線上應用程式商店。點擊下方「加入至 Chrome」即可安裝。即將支援 Microsoft Edge、Safari、Firefox。"
+    items={[
+      {
+        title: '語境感知解釋——更容易理解',
+        description: '不認識字幕中的單字？滑過並點擊，即可取得結合當前語境、符合你程度的 AI 解釋。',
+      },
+      { title: '有問題？繼續追問', description: '搞不清相似的單字？在相同語境中繼續追問，獲得清楚解釋。' },
+      {
+        title: 'AI 翻譯字幕——雙語字幕',
+        description: '想輕鬆看影片？Acquire Language 將字幕翻譯為你偏好的語言並雙語顯示。',
+      },
+      {
+        title: '同步單字本——隨時複習',
+        description: '保存單字（含語境）、片段，甚至音訊。同步到你常用的筆記應用，隨時複習加深記憶。',
+      },
+    ]}
+    image={`<img src="${screenshotEn.src}" alt="安裝 Acquire Language" class="mx-auto w-full rounded-lg bg-gray-500 shadow-lg" width="440" height="280" loading="lazy" />`}
+    callToAction={{
+      variant: 'primary',
+      text: '加入至 Chrome',
+      href: 'https://chrome.google.com/webstore/detail/pnobdlbfobamledoecdignpneeoohhio',
+      target: '_blank',
+      icon: 'tabler:brand-chrome',
+    }}
+  />
+
+  <Steps
+    title="設定 Acquire Language"
+    items={[
+      {
+        title: '步驟 1：<span class="font-medium">選擇語言與程度</span>',
+        description: '設定你想學的語言與目前程度，以更符合你的需求',
+        icon: 'tabler:language',
+      },
+      {
+        title: '步驟 2：<span class="font-medium">設定 AI 服務</span>',
+        description: '開啟 設定 -> AI 服務 以設定你自己的 AI 服務',
+        icon: 'tabler:settings',
+      },
+      {
+        title: '步驟 3：<span class="font-medium">設定單字本同步</span>',
+        description: '設定整合與歐路詞典等服務，把單字同步到你的單字本',
+        icon: 'tabler:arrows-right-left',
+      },
+      {
+        title: '步驟 4：<span class="font-medium">啟用字幕</span>',
+        description: '開啟任一 YouTube 影片並啟用字幕',
+        icon: 'tabler:video',
+      },
+      { title: '準備完成！', icon: 'tabler:check' },
+    ]}
+    image={`<img src="${setupReady.src}" alt="設定完成" class="mx-auto w-full rounded-lg shadow-lg" loading="lazy" />`}
+  />
+</Layout>


### PR DESCRIPTION
Add Simplified and Traditional Chinese language support using Astro's built-in i18n.

This PR enables `zh-CN` and `zh-TW` locales, introduces a language picker component, localizes navigation links, dynamically sets the `html lang` attribute, and provides localized versions of the `index` and `about` pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6bce6e0-44a1-4760-bc02-afd01a06552e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f6bce6e0-44a1-4760-bc02-afd01a06552e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

